### PR TITLE
[WIP] Docker update and outsourced caddy setup

### DIFF
--- a/aoc_cli/aoc.py
+++ b/aoc_cli/aoc.py
@@ -1,6 +1,7 @@
 import click
 
 from aoc_cli.init import init
+from aoc_cli.uninstall import uninstall
 
 
 @click.group()
@@ -11,3 +12,4 @@ def cli() -> None:
 
 
 cli.add_command(init)
+cli.add_command(uninstall)

--- a/aoc_cli/commands/uninstall.py
+++ b/aoc_cli/commands/uninstall.py
@@ -5,9 +5,9 @@ from pathlib import Path
 
 @dataclass
 class UninstallCommandArgs:
-    force: bool
-    remove_data: bool
-    aoc_dir: Path
+    force: bool = False
+    remove_data: bool = False
+    aoc_dir: Path = Path.home() / ".config" / "bitswan" / "aoc"
 
 
 class UninstallCommand:
@@ -15,7 +15,7 @@ class UninstallCommand:
         self.args = args
 
     def execute(self) -> None:
-        aoc_dir = self.args.aoc_dir
+        aoc_dir = Path(self.args.aoc_dir)
 
         if not aoc_dir.exists():
             print(f"AOC is not installed at path {aoc_dir}")

--- a/aoc_cli/commands/uninstall.py
+++ b/aoc_cli/commands/uninstall.py
@@ -51,16 +51,16 @@ class UninstallCommand:
         try:
             if remove_volumes:
                 subprocess.run(
-                    ["docker-compose", "down", "-v"], cwd=aoc_dir, check=True
+                    ["docker", "compose", "down", "-v"], cwd=aoc_dir, check=True
                 )
             else:
-                subprocess.run(["docker-compose", "down"], cwd=aoc_dir, check=True)
+                subprocess.run(["docker", "compose", "down"], cwd=aoc_dir, check=True)
         except subprocess.CalledProcessError as e:
             print(f"Warning: Failed to stop services: {e}")
 
     def _remove_containers(self, aoc_dir: Path) -> None:
         try:
-            subprocess.run(["docker-compose", "rm"], cwd=aoc_dir, check=True)
+            subprocess.run(["docker", "compose", "rm"], cwd=aoc_dir, check=True)
         except subprocess.CalledProcessError as e:
             print(f"Warning: Failed to remove containers: {e}")
 

--- a/aoc_cli/config/__init__.py
+++ b/aoc_cli/config/__init__.py
@@ -16,7 +16,7 @@ class Protocol(Enum):
 @dataclass
 class InitConfig:
     env: Environment
-    aoc_dir: Path = Path.home() / ".aoc"
+    aoc_dir: Path = Path.home() / ".config" / "bitswan" / "aoc"
     domain: str = "platform.local"
     protocol: Protocol = Protocol.HTTP
     admin_email: str = "admin@platform.local"

--- a/aoc_cli/config/variables.py
+++ b/aoc_cli/config/variables.py
@@ -32,7 +32,7 @@ def get_var_defaults(
         # Postgres defaults - using internal names for Keycloak and Bitswan backend postgres instances
         "KEYCLOAK_POSTGRES_USER": "postgres",
         "KEYCLOAK_POSTGRES_DB": "postgres",
-        "KEYCLOAK_POSTGRES_HOST": "postgres",
+        "KEYCLOAK_POSTGRES_HOST": "aoc-keycloak-postgres",
         "KEYCLOAK_POSTGRES_PORT": "5432",
         "BITSWAN_POSTGRES_USER": "postgres",
         "BITSWAN_POSTGRES_DB": "bitswan_backend",
@@ -45,7 +45,7 @@ def get_var_defaults(
         "KC_PROXY": "edge",
         "KC_DB": "postgres",
         "DB_ADDR": "postgres",
-        "KC_DB_URL_HOST": "postgres",
+        "KC_DB_URL_HOST": "aoc-keycloak-postgres",
         "KC_DB_URL_DATABASE": "postgres",
         "KC_DB_USERNAME": "postgres",
         "PORTAINER_BASE_URL": "http://aoc-portainer:9000/",

--- a/aoc_cli/init.py
+++ b/aoc_cli/init.py
@@ -15,6 +15,8 @@ from aoc_cli.config import Environment, InitConfig, Protocol
 @click.command()
 @click.argument(
     "output_dir",
+    required=False,
+    default=Path.home() / ".config" / "bitswan" / "aoc",
     type=click.Path(exists=False, writable=True, file_okay=False, resolve_path=True),
 )
 @click.option("--overwrite", is_flag=True, help="Overwrite existing files")
@@ -71,7 +73,7 @@ async def _init_async(
 
     init_config = InitConfig(
         env=Environment(configs.get("env")),
-        aoc_dir=Path(f"{output_dir}/aoc"),
+        aoc_dir=Path(output_dir),
         protocol=Protocol(configs.get("protocol")),
         domain=configs.get("domain"),
         admin_email=configs.get("admin_email"),

--- a/aoc_cli/init.py
+++ b/aoc_cli/init.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import asyncio
 
 import click
 
@@ -37,6 +38,16 @@ def init(
     overwrite,
     **kwargs,
 ):
+    asyncio.run(_init_async(ctx, output_dir, env_file, overwrite, **kwargs))
+
+
+async def _init_async(
+    ctx,
+    output_dir: Path,
+    env_file,
+    overwrite,
+    **kwargs,
+):
     """Initialize the Automation Operations Center (AOC)."""
     click.echo("Initializing AoC...\n")
 
@@ -69,4 +80,4 @@ def init(
     )
 
     handler = InitCommand(init_config)
-    handler.execute()
+    await handler.execute()

--- a/aoc_cli/services/caddy.py
+++ b/aoc_cli/services/caddy.py
@@ -1,4 +1,6 @@
 import subprocess
+import aiohttp
+import asyncio
 
 from aoc_cli.config import Environment, InitConfig
 
@@ -6,56 +8,89 @@ from aoc_cli.config import Environment, InitConfig
 class CaddyService:
     def __init__(self, config: InitConfig):
         self.config = config
-        self.caddyfile_path = config.aoc_dir / "Caddyfile"
+        self.outsourced = False #gets set to true in initialize when caddy admin is found
+        self.caddyfile_path = None
 
-    def add_proxy(self, domain: str, target: str):
-        self._update_caddyfile(domain, target)
-
-    def _update_caddyfile(self, domain: str, target: str):
-        config = f"""
-            {domain} {{
-                reverse_proxy {target}
-            }}
-        """
-
-        with open(self.caddyfile_path, "a") as f:
-            f.write(config)
-
-    def initialize(self) -> None:
-        directories = [
-            self.config.aoc_dir / "caddy_data",
-            self.config.aoc_dir / "caddy_config",
-        ]
-
-        try:
-            for directory in directories:
-                directory.mkdir(parents=True, exist_ok=True)
-                print(f"Created directory: {directory}")
-
-            caddyfile_content = """
-                {
-                    auto_https off
-                }"""
-
-            if self.config.env == Environment.PROD:
-                # Production environment
-                caddyfile_content = f"""
-                {{
-                    email {self.config.admin_email}
+    async def add_proxy(self, domain: str, target: str):
+        if not self.outsourced:
+            config = f"""
+                {domain} {{
+                    reverse_proxy {target}
                 }}
-                """
+            """
 
-            caddyfile_path = self.config.aoc_dir / "Caddyfile"
-            with open(caddyfile_path, "w", encoding="utf-8") as f:
-                f.write(caddyfile_content)
-            print(f"Created Caddyfile: {caddyfile_path}")
+            with open(self.caddyfile_path, "a") as f:
+                f.write(config)
+        else:
+            gitops_routes_url = "http://localhost:2019/config/apps/http/servers/srv0/routes"
+            payload = {
+                "match": [{"host": [domain]}],
+                "handle": [{
+                    "handler": "subroute",
+                    "routes": [{
+                        "handle": [{
+                            "handler": "reverse_proxy",
+                            "upstreams": [{"dial": target}]
+                        }]
+                    }]
+                }],
+                "terminal": True
+            }
+            async with aiohttp.ClientSession() as session:
+                async with session.post(gitops_routes_url, json=payload) as response:
+                    response_text = await response.text()
+                    print(f"Status: {response.status}")
+                    print(f"Response: {response_text}")
+                    print(f"Added route {domain} pointing to {target}")
 
-        except OSError as e:
-            raise OSError(f"Failed to set up Caddy service: {str(e)}")
+    async def initialize(self) -> None:
+        async with aiohttp.ClientSession() as session:
+            try:
+                resp = await (await session.get("http://localhost:2019/config", timeout=2)).json()
+                self.outsourced = bool(resp['admin'].get('listen'))
+                print("Caddy with admin at port 2019 running. Using that instead")
+            except:
+                self.outsourced = False
+
+        if not self.outsourced:
+            self.caddyfile_path = self.config.aoc_dir / "Caddyfile"
+            directories = [
+                self.config.aoc_dir / "caddy_data",
+                self.config.aoc_dir / "caddy_config",
+            ]
+
+            try:
+                for directory in directories:
+                    directory.mkdir(parents=True, exist_ok=True)
+                    print(f"Created directory: {directory}")
+
+                caddyfile_content = """
+                    {
+                        auto_https off
+                    }"""
+
+                if self.config.env == Environment.PROD:
+                    # Production environment
+                    caddyfile_content = f"""
+                    {{
+                        email {self.config.admin_email}
+                    }}
+                    """
+
+                caddyfile_path = self.config.aoc_dir / "Caddyfile"
+                with open(caddyfile_path, "w", encoding="utf-8") as f:
+                    f.write(caddyfile_content)
+                print(f"Created Caddyfile: {caddyfile_path}")
+
+            except OSError as e:
+                raise OSError(f"Failed to set up Caddy service: {str(e)}")
+        else:
+            pass
 
     def start(self) -> None:
-        subprocess.run(
-            ["docker-compose", "up", "-d", "caddy"],
-            cwd=self.config.aoc_dir,
-            check=True,
-        )
+        if not self.outsourced:
+            subprocess.run(
+                ["docker", "compose", "up", "-d", "caddy"],
+                cwd=self.config.aoc_dir,
+                check=True,
+            )

--- a/aoc_cli/services/influxdb.py
+++ b/aoc_cli/services/influxdb.py
@@ -66,7 +66,7 @@ class InfluxDBService:
         """Start the InfluxDB service using docker-compose"""
         print("Starting InfluxDB service...")
         subprocess.run(
-            ["docker-compose", "up", "--quiet-pull", "-d", "influxdb"],
+            ["docker", "compose", "up", "--quiet-pull", "-d", "influxdb"],
             cwd=self.config.aoc_dir,
             check=True,
         )

--- a/aoc_cli/services/keycloak.py
+++ b/aoc_cli/services/keycloak.py
@@ -44,7 +44,7 @@ class KeycloakService:
 
     def start_services(self) -> None:
         subprocess.run(
-            ["docker-compose", "up", "--quiet-pull", "-d", "keycloak", "postgres"],
+            ["docker", "compose", "up", "--quiet-pull", "-d", "keycloak", "postgres"],
             cwd=self.config.aoc_dir,
             check=True,
         )

--- a/aoc_cli/templates/prod/docker-compose.yml
+++ b/aoc_cli/templates/prod/docker-compose.yml
@@ -9,18 +9,6 @@ volumes:
   bitswan-editor-data:
 
 services:
-  caddy:
-    image: caddy:latest
-    restart: always
-    ports:
-      - "80:80"
-      - "443:443"
-    volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile:ro
-      - ./caddy_data:/data
-      - ./caddy_config:/config
-
-
   influxdb:
     image: influxdb:2.0
     restart: always
@@ -71,7 +59,7 @@ services:
   postgres:
     image: postgres:12-bullseye
     restart: always
-    container_name: aoc-postgres
+    container_name: aoc-keycloak-postgres
     volumes:
       - postgres-keycloak-data:/var/lib/postgresql/data
     env_file: envs/keycloak-postgres.env
@@ -92,6 +80,7 @@ services:
 
   bitswan-backend:
     image: bitswan/bitswan-backend:2025-13211829799-git-65ce7c8
+    container_name: bitswan-backend
     depends_on:
       - bitswan-backend-postgres
     restart: always
@@ -104,6 +93,7 @@ services:
 
   bitswan-backend-postgres:
     image: postgres:15-bullseye
+    container_name: bitswan-backend-postgres
     restart: always
     volumes:
       - bitswan_backend_production_postgres_data:/var/lib/postgresql/data

--- a/aoc_cli/uninstall.py
+++ b/aoc_cli/uninstall.py
@@ -2,7 +2,6 @@ import click
 
 from aoc_cli.commands.uninstall import UninstallCommand, UninstallCommandArgs
 
-
 @click.command()
 @click.option("--force", is_flag=True, help="Skip confirmation prompts")
 @click.option("--remove-data", is_flag=True, help="Remove all data as well")

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -4,36 +4,13 @@ volumes:
   portainer_data:
   influx_data:
   influx_config:
-  mosquitto_data:
-  mosquitto_log:
   postgres-keycloak-data:
   emqx_data:
   bitswan_backend_production_postgres_data: {}
   bitswan_backend_production_postgres_data_backups: {}
-  production_traefik: {}
   bitswan-editor-data:
 
 services:
-  caddy:
-    image: caddy:latest
-    restart: always
-    ports:
-      - "80:80"
-      - "443:443"
-    volumes:
-      - ./Caddyfile:/etc/caddy/Caddyfile:ro
-      - ./caddy_data:/data
-      - ./caddy_config:/config
-    environment:
-      - DOMAIN="http://platform.local"
-    networks:
-      default:
-        aliases:
-          - "platform.local"
-          - "poc.platform.local"
-          - "influx.platform.local"
-          - "keycloak.platform.local"
-
   influxdb:
     image: influxdb:2.0
     restart: always
@@ -70,6 +47,7 @@ services:
 
   keycloak:
     image: bitswan/bitswan-keycloak:2024-9110295480-git-d7a8e49
+    container_name: "aoc-keycloak"
     restart: always
     env_file:
       - .keycloak.env
@@ -77,6 +55,7 @@ services:
 
   postgres:
     image: postgres:12-bullseye
+    container_name: "aoc-keycloak-postgres"
     restart: always
     volumes:
       - postgres-keycloak-data:/var/lib/postgresql/data
@@ -87,6 +66,7 @@ services:
     restart: always
 
   automation-operation-centre:
+    container_name: "automation-operation-centre"
     restart: always
     image: bitswan/automation-operations-centre:2024-11950867795-git-5ff440c
     env_file: .operations-centre.env


### PR DESCRIPTION
This work in progress pull gestures at running `aoc` in situations where the caddy configuration was already done by [bitswan-gitops-cli](https://github.com/bitswan-space/bitswan-gitops-cli). This exposes the Caddy admin API`localhost:2019`, through which `CaddyService.add_proxy` can register the services.

Also running the `docker-ce` package, `docker-compose` is now replaced with `docker compose`. Currently I replaced this in the code, but perhaps we may want to include some sort of switch on docker version to alternate between both?