### PR TITLE
Small UI fixes

### DIFF
--- a/nextjs/src/components/groups/MQTTProfileSelector.tsx
+++ b/nextjs/src/components/groups/MQTTProfileSelector.tsx
@@ -67,11 +67,11 @@ export default function MQTTProfileSelector(props: MQTTProfileSelectorProps) {
       <SelectContent className="bg-neutral-100">
         <SelectGroup>
           <SelectLabel>
-            <div>MQTT profiles</div>
+            <div>Groups</div>
             {mqttProfiles?.results?.length === 0 && (
               <div className="mt-2 flex h-16 flex-col items-center justify-center gap-2 rounded border border-dashed">
                 <div className="text-center text-sm font-normal text-neutral-500">
-                  No mqtt profiles found
+                  No groups found
                 </div>
               </div>
             )}

--- a/nextjs/src/components/pipeline/PipelineDataTable.tsx
+++ b/nextjs/src/components/pipeline/PipelineDataTable.tsx
@@ -73,7 +73,7 @@ export const columns = [
     header: "Workspace Name",
     cell: ({ row }) => {
       const machineName = row.original.properties["endpoint-name"];
-      return <div className="text-xs capitalize">{machineName}</div>;
+      return <div className="text-xs">{machineName}</div>;
     },
   }),
   columnHelper.accessor("properties.state", {


### PR DESCRIPTION
- Changed 'MQTT Profiles' label to 'Groups' in profile selector
- Removed capitalization from workspace name in automations table